### PR TITLE
quick fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2697,6 +2697,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4956,6 +4965,7 @@ dependencies = [
  "graphcast-sdk",
  "graphql_client",
  "hex",
+ "itertools 0.11.0",
  "metrics 0.21.1",
  "num-traits",
  "once_cell",

--- a/subgraph-radio/Cargo.toml
+++ b/subgraph-radio/Cargo.toml
@@ -34,6 +34,7 @@ dotenv = "0.15"
 rand = "0.8.5"
 secp256k1 = "0.27.0"
 hex = "0.4.3"
+itertools = "0.11.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = [
     "env-filter",

--- a/subgraph-radio/src/config.rs
+++ b/subgraph-radio/src/config.rs
@@ -8,9 +8,7 @@ use graphcast_sdk::{
     graphcast_agent::{
         message_typing::IdentityValidation, GraphcastAgentConfig, GraphcastAgentError,
     },
-    graphql::{
-        client_network::query_network_subgraph, client_registry::query_registry, QueryError,
-    },
+    graphql::{client_network::query_network_subgraph, QueryError},
     init_tracing, wallet_address,
 };
 
@@ -365,17 +363,9 @@ impl Config {
         .await
     }
 
-    pub async fn basic_info(&self) -> Result<(String, f32), QueryError> {
-        // Using unwrap directly as the query has been ran in the set-up validation
-        let wallet = build_wallet(
-            self.wallet_input()
-                .map_err(|e| QueryError::Other(e.into()))?,
-        )
-        .map_err(|e| QueryError::Other(e.into()))?;
-        // The query here must be Ok but so it is okay to panic here
-        // Alternatively, make validate_set_up return wallet, address, and stake
-        let my_address = query_registry(self.registry_subgraph(), &wallet_address(&wallet)).await?;
-        let my_stake = query_network_subgraph(self.network_subgraph(), &my_address)
+    pub async fn basic_info(&self) -> Result<(&str, f32), QueryError> {
+        let my_address = self.indexer_address();
+        let my_stake = query_network_subgraph(self.network_subgraph(), my_address)
             .await
             .unwrap()
             .indexer_stake();

--- a/subgraph-radio/src/messages/poi.rs
+++ b/subgraph-radio/src/messages/poi.rs
@@ -24,7 +24,7 @@ use graphcast_sdk::{
 };
 
 use crate::{
-    metrics::CACHED_MESSAGES,
+    metrics::CACHED_PPOI_MESSAGES,
     operator::{
         attestation::{
             compare_attestations, local_comparison_point, save_local_attestation, Attestation,
@@ -297,7 +297,7 @@ pub async fn process_valid_message(
     let identifier = msg.identifier.clone();
 
     state.add_remote_ppoi_message(msg.clone());
-    CACHED_MESSAGES.with_label_values(&[&identifier]).set(
+    CACHED_PPOI_MESSAGES.with_label_values(&[&identifier]).set(
         state
             .remote_ppoi_messages()
             .iter()

--- a/subgraph-radio/src/metrics/mod.rs
+++ b/subgraph-radio/src/metrics/mod.rs
@@ -17,7 +17,7 @@ pub static VALIDATED_MESSAGES: Lazy<IntCounterVec> = Lazy::new(|| {
         Opts::new("validated_messages", "Number of validated messages")
             .namespace("graphcast")
             .subsystem("subgraph_radio"),
-        &["deployment"],
+        &["deployment", "message_type"],
     )
     .expect("Failed to create validated_messages counters");
     prometheus::register(Box::new(m.clone()))
@@ -27,15 +27,16 @@ pub static VALIDATED_MESSAGES: Lazy<IntCounterVec> = Lazy::new(|| {
 
 // Received (and validated) messages counter
 #[allow(dead_code)]
-pub static CACHED_MESSAGES: Lazy<IntGaugeVec> = Lazy::new(|| {
+pub static CACHED_PPOI_MESSAGES: Lazy<IntGaugeVec> = Lazy::new(|| {
     let m = IntGaugeVec::new(
-        Opts::new("cached_messages", "Number of messages in cache")
+        Opts::new("cached_ppoi_messages", "Number of messages in cache")
             .namespace("graphcast")
             .subsystem("subgraph_radio"),
         &["deployment"],
     )
-    .expect("Failed to create cached_messages gauges");
-    prometheus::register(Box::new(m.clone())).expect("Failed to register cached_messages guage");
+    .expect("Failed to create cached_ppoi_messages gauges");
+    prometheus::register(Box::new(m.clone()))
+        .expect("Failed to register cached_ppoi_messages guage");
     m
 });
 
@@ -128,7 +129,7 @@ pub fn start_metrics() {
         &REGISTRY,
         vec![
             Box::new(VALIDATED_MESSAGES.clone()),
-            Box::new(CACHED_MESSAGES.clone()),
+            Box::new(CACHED_PPOI_MESSAGES.clone()),
             Box::new(ACTIVE_INDEXERS.clone()),
             Box::new(DIVERGING_SUBGRAPHS.clone()),
             Box::new(LOCAL_PPOIS_TO_COMPARE.clone()),

--- a/subgraph-radio/src/operator/operation.rs
+++ b/subgraph-radio/src/operator/operation.rs
@@ -13,7 +13,7 @@ use graphcast_sdk::{
 use crate::messages::poi::{poi_message_comparison, send_poi_message};
 
 use crate::{
-    metrics::CACHED_MESSAGES,
+    metrics::CACHED_PPOI_MESSAGES,
     operator::{attestation::ComparisonResult, RadioOperator},
     OperationError, GRAPHCAST_AGENT,
 };
@@ -169,7 +169,7 @@ impl RadioOperator {
                             .clean_local_attestations(r.block(), r.deployment_hash());
                         self.persisted_state
                             .clean_remote_ppoi_messages(r.block(), r.deployment_hash());
-                        CACHED_MESSAGES
+                        CACHED_PPOI_MESSAGES
                             .with_label_values(&[&r.deployment_hash()])
                             .set(
                                 self.state()

--- a/subgraph-radio/src/server/model/mod.rs
+++ b/subgraph-radio/src/server/model/mod.rs
@@ -141,7 +141,7 @@ impl QueryRoot {
             .await
             .map_err(HttpServiceError::QueryError)?;
         Ok(IndexerInfo {
-            address: basic_info.0,
+            address: basic_info.0.to_string(),
             stake: basic_info.1,
         })
     }


### PR DESCRIPTION
### Description

- Message type added as a label for validated messages metrics
- Cached messages renamed to be specific to PublicPoiMessage
- Since self setup is validated initialization, the supplied `indexer_address` can be used directly when serving the response to comparisonRatios 


### Checklist
- [x] Are tests up-to-date with the new changes? 
- [x] Are docs up-to-date with the new changes? (Open PR on docs repo if necessary)
