### PR TITLE
indexer management client, health check, basic requests

### DIFF
--- a/subgraph-radio/benches/gossips.rs
+++ b/subgraph-radio/benches/gossips.rs
@@ -31,6 +31,7 @@ fn gossip_poi_bench(c: &mut Criterion) {
             network_subgraph: String::from(
                 "https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-goerli",
             ),
+            indexer_management_server_endpoint: None,
         },
         waku: Waku {
             waku_host: None,
@@ -65,6 +66,7 @@ fn gossip_poi_bench(c: &mut Criterion) {
             topic_update_interval: 600,
             log_format: LogFormat::Pretty,
             graphcast_network: GraphcastNetworkName::Testnet,
+            auto_upgrade: CoverageLevel::Comprehensive,
         },
         config_file: None,
     });

--- a/subgraph-radio/src/operator/indexer_management.rs
+++ b/subgraph-radio/src/operator/indexer_management.rs
@@ -1,0 +1,170 @@
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::OperationError;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct IndexingRuleAttributes {
+    id: i32,
+    identifier: String,
+    identifier_type: String,
+    allocation_amount: Option<String>,
+    allocation_lifetime: Option<i32>,
+    auto_renewal: bool,
+    parallel_allocations: Option<i32>,
+    max_allocation_percentage: Option<i32>,
+    min_signal: Option<String>,
+    max_signal: Option<String>,
+    min_stake: Option<String>,
+    min_average_query_fees: Option<String>,
+    custom: Option<String>,
+    decision_basis: String,
+    require_supported: bool,
+    safety: bool,
+}
+
+pub async fn health_query(url: &str) -> Result<String, OperationError> {
+    let client = Client::new();
+    let response = client.get(url).send().await.unwrap();
+    response
+        .text()
+        .await
+        .map_err(|e| OperationError::Query(graphcast_sdk::graphql::QueryError::Transport(e)))
+}
+
+pub async fn indexing_rules(url: &str) -> Result<serde_json::Value, OperationError> {
+    let graphql_query = json!({
+        "query": r#"query indexingRules {
+                indexingRules {
+                    identifier
+                    identifierType
+                    allocationAmount
+                    allocationLifetime
+                    autoRenewal
+                    parallelAllocations
+                    maxAllocationPercentage
+                    minSignal
+                    maxSignal
+                    minStake
+                    minAverageQueryFees
+                    custom
+                    decisionBasis
+                    requireSupported
+                    safety
+                }
+            }"#
+    });
+
+    let client = Client::new();
+    let response = client.post(url).json(&graphql_query).send().await.unwrap();
+
+    response
+        .json::<serde_json::Value>()
+        .await
+        .map_err(|e| OperationError::Query(graphcast_sdk::graphql::QueryError::Transport(e)))
+}
+
+pub async fn offchain_sync_indexing_rules(
+    url: &str,
+    deployment: &str,
+) -> Result<serde_json::Value, OperationError> {
+    let graphql_mutation = json!({
+        "query": r#"mutation updateIndexingRule($rule: IndexingRuleInput!) {
+            setIndexingRule(rule: $rule) {
+                identifier
+                identifierType
+                allocationAmount
+                allocationLifetime
+                autoRenewal
+                parallelAllocations
+                maxAllocationPercentage
+                minSignal
+                maxSignal
+                minStake
+                minAverageQueryFees
+                custom
+                decisionBasis
+                requireSupported
+                safety
+            }
+        }"#,
+        "variables": {
+            "rule": {
+                "identifier": deployment,
+                "decisionBasis": "offchain",
+                "identifierType": "deployment"
+            }
+        }
+    });
+
+    let client = Client::new();
+    let response = client
+        .post(url)
+        .json(&graphql_mutation)
+        .send()
+        .await
+        .map_err(|e| OperationError::Query(graphcast_sdk::graphql::QueryError::Transport(e)))?;
+
+    response
+        .json::<serde_json::Value>()
+        .await
+        .map_err(|e| OperationError::Query(graphcast_sdk::graphql::QueryError::Transport(e)))
+}
+
+// // NOTE: this set of tests can only run in context of running indexer_management server
+// #[cfg(test)]
+// mod tests {
+
+//     use super::*;
+
+//     // TODO: add setup and teardown functions
+
+//     #[tokio::test]
+//     async fn test_basic_request() {
+//         let res = health_query("http://127.0.0.1:18000").await.unwrap();
+
+//         assert_eq!(res, "Ready to roll!".to_string());
+//     }
+
+//     #[tokio::test]
+//     async fn test_query_indexing_rule() {
+//         let res_json = indexing_rules("http://127.0.0.1:18000").await;
+
+//         assert!(res_json.is_ok())
+//     }
+
+//     #[tokio::test]
+//     async fn test_set_offchain_sync() {
+//         let res_json = offchain_sync_indexing_rules(
+//             "http://127.0.0.1:18000",
+//             "Qmb5Ysp5oCUXhLA8NmxmYKDAX2nCMnh7Vvb5uffb9n5vss",
+//         )
+//         .await;
+//         assert!(res_json.is_ok());
+
+//         let check_setting = indexing_rules("http://127.0.0.1:18000").await.unwrap();
+
+//         assert!(check_setting
+//             .as_object()
+//             .unwrap()
+//             .get("data")
+//             .unwrap()
+//             .as_object()
+//             .unwrap()
+//             .get("iiterles")
+//             .unwrap()
+//             .as_array()
+//             .unwrap()
+//             .into_iter()
+//             .any(|o| o
+//                 .as_object()
+//                 .unwrap()
+//                 .get("identifier")
+//                 .unwrap()
+//                 .as_str()
+//                 .unwrap()
+//                 == "Qmb5Ysp5oCUXhLA8NmxmYKDAX2nCMnh7Vvb5uffb9n5vss")
+//             );
+//     }
+// }

--- a/subgraph-radio/src/state.rs
+++ b/subgraph-radio/src/state.rs
@@ -15,13 +15,14 @@ use tracing::{info, trace, warn};
 
 use graphcast_sdk::graphcast_agent::message_typing::GraphcastMessage;
 
-use crate::operator::attestation::{
-    clear_local_attestation, ComparisonResult, ComparisonResultType,
+use crate::{
+    messages::poi::PublicPoiMessage,
+    operator::attestation::{
+        clear_local_attestation, Attestation, ComparisonResult, ComparisonResultType,
+    },
+    operator::notifier::Notifier,
+    RADIO_OPERATOR,
 };
-use crate::operator::notifier::Notifier;
-use crate::RADIO_OPERATOR;
-
-use crate::{messages::poi::PublicPoiMessage, operator::attestation::Attestation};
 
 type Local = Arc<SyncMutex<HashMap<String, HashMap<u64, Attestation>>>>;
 type Remote = Arc<SyncMutex<Vec<GraphcastMessage<PublicPoiMessage>>>>;

--- a/test-utils/src/config.rs
+++ b/test-utils/src/config.rs
@@ -36,6 +36,7 @@ pub fn test_config() -> Config {
                 mnemonic: None,
                 registry_subgraph: String::new(),
                 network_subgraph: String::new(),
+                indexer_management_server_endpoint: None,
             }
         },
         waku: {
@@ -74,6 +75,7 @@ pub fn test_config() -> Config {
                 telegram_token: None,
                 id_validation: IdentityValidation::ValidAddress,
                 topic_update_interval: 600,
+                auto_upgrade: CoverageLevel::OnChain,
             }
         },
         config_file: None,

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -185,6 +185,7 @@ pub fn start_radio(config: &Config) -> Child {
         .arg(config.radio_infrastructure().topics.join(","))
         .arg("--coverage")
         .arg(match config.radio_infrastructure().coverage {
+            CoverageLevel::None => "none",
             CoverageLevel::Minimal => "minimal",
             CoverageLevel::OnChain => "on-chain",
             CoverageLevel::Comprehensive => "comprehensive",


### PR DESCRIPTION
### Description

- Add options to provide indexer management server endpoint (`INDEXER_MANAGEMENT_SERVER_ENDPOINT`) and coverage level for automatically upgradeable subgraphs (`AUTO_UPGRADE`)
- basic health check to the endpoint at radio initialization
- requests: get all indexing rules, post offchain sync request
- added `None` to coverage level
- Unit tests relies on a running indexer server so temporarily commented out until there is a mock server 

No changes required for the users.

### Issue link (if applicable)

Resolves #23 

### Checklist
- [x] Are tests up-to-date with the new changes? 
- [x] Are docs up-to-date with the new changes? (Open PR on docs repo if necessary)
