### PR TITLE
chore: update labels workflow

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Add Awaiting Triage Label
         uses: actions-cool/issues-helper@v3
         with:
-          actions: 'add-labels'
+          actions: "add-labels"
           token: ${{ secrets.LABELS_TOKEN }}
           issue-number: ${{ github.event.issue.number }}
-          labels: 'awaiting-triage'
+          labels: "meta:awaiting-triage"


### PR DESCRIPTION
updated `awaiting-triage` to `meta:awaiting-triage`