### PR TITLE
feat: allow read config file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1017,6 +1017,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "confy"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e37668cb35145dcfaa1931a5f37fde375eeae8068b4c0d2f289da28a270b2d2c"
+dependencies = [
+ "directories",
+ "serde",
+ "thiserror",
+ "toml 0.5.11",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1433,6 +1445,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1440,6 +1461,17 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -5023,6 +5055,7 @@ dependencies = [
  "cargo-husky",
  "chrono",
  "clap 4.3.19",
+ "confy",
  "criterion",
  "derive-getters",
  "dotenv",

--- a/subgraph-radio/Cargo.toml
+++ b/subgraph-radio/Cargo.toml
@@ -53,6 +53,7 @@ metrics = "0.21.0"
 opentelemetry = { version = "0.19.0", features = ["rt-tokio", "trace"] }
 tracing-opentelemetry = "0.18.0"
 clap = { version = "4.3.1", features = ["derive", "env"] }
+confy = "0.5.1"
 
 [dev-dependencies]
 criterion = { version = "0.4", features = ["async", "async_futures"] }

--- a/subgraph-radio/src/config.rs
+++ b/subgraph-radio/src/config.rs
@@ -53,8 +53,18 @@ pub struct Config {
 impl Config {
     /// Parse config arguments
     pub fn args() -> Self {
-        // TODO: load config file before parse (maybe add new level of subcommands)
-        let config = Config::parse();
+        let config = if let Ok(file_path) = std::env::var("CONFIG_FILE") {
+            confy::load_path::<Config>(file_path.clone()).unwrap_or_else(|e| {
+                panic!(
+                    "{} file cannot be parsed into Config: {}",
+                    file_path.clone(),
+                    e
+                )
+            })
+        } else {
+            Config::parse()
+        };
+
         std::env::set_var("RUST_LOG", config.radio_infrastructure().log_level.clone());
         // Enables tracing under RUST_LOG variable
         init_tracing(config.radio_infrastructure().log_format.to_string()).expect("Could not set up global default subscriber for logger, check environmental variable `RUST_LOG` or the CLI input `log-level`");

--- a/template.toml
+++ b/template.toml
@@ -1,0 +1,27 @@
+[graph_stack]
+graph_node_status_endpoint = 'http://localhost:8030/graphql'
+indexer_address = '0xgossipssssssssssssssssssssssssssssssssss'
+registry_subgraph = 'https://api.thegraph.com/subgraphs/name/hopeyen/graphcast-registry-goerli'
+network_subgraph = 'https://api.thegraph.com/subgraphs/name/graphprotocol/graph-network-goerli'
+private_key = 'abcdefghabcdefghabcdefghabcdefghabcdefghabcdefghabcdefghabcdefgh'
+indexer_management_server_endpoint = 'http://127.0.0.1:18000'
+
+[waku]
+boot_node_addresses = []
+
+[radio_infrastructure]
+graphcast_network = 'Testnet'
+topics = ['QmacQnSgia4iDPWHpeY6aWxesRFdb8o5DKZUx96zZqEWrB']
+coverage = 'Comprehensive'
+auto_upgrade = 'Comprehensive'
+collect_message_duration = 10
+slack_token = 'xoxb-1231231231231-2312312312312-3abcabcabcabacabcabcabca'
+metrics_host = '0.0.0.0'
+server_host = '0.0.0.0'
+server_port = 7700
+persistence_file_path = 'wooooooow.json'
+radio_name = 'subgraph-radio'
+id_validation = 'ValidAddress'
+topic_update_interval = 600
+log_level = 'warn,hyper=off,graphcast_sdk=debug,subgraph_radio=debug'
+log_format = 'Pretty'


### PR DESCRIPTION
### Description

Allow user to set `CONFIG_FILE` env var as an alternative way to startup

### Issue link (if applicable)

Resolves #31

### Checklist
- [x] Are tests up-to-date with the new changes? 
- [x] Are docs up-to-date with the new changes? (Open PR on docs repo if necessary)
