### PR TITLE
feat: persist and clean upgrade intent msg, ratelimit, and API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ data
 .vscode
 *.json
 .DS_Store
+configs

--- a/subgraph-radio/benches/gossips.rs
+++ b/subgraph-radio/benches/gossips.rs
@@ -53,6 +53,7 @@ fn gossip_poi_bench(c: &mut Criterion) {
             )],
             coverage: CoverageLevel::Comprehensive,
             collect_message_duration: 10,
+            ratelimit_threshold: 60000,
             log_level: String::from("info"),
             slack_token: None,
             slack_channel: None,

--- a/subgraph-radio/src/config.rs
+++ b/subgraph-radio/src/config.rs
@@ -153,7 +153,7 @@ impl Config {
             state
         } else {
             debug!("Created new state");
-            PersistedState::new(None, None, None)
+            PersistedState::new(None, None, None, None)
         }
     }
 
@@ -311,6 +311,15 @@ pub struct RadioInfrastructure {
             none: no automatic upgrade, only notifications.\nDefault: comprehensive"
     )]
     pub auto_upgrade: CoverageLevel,
+    #[clap(
+        long,
+        value_parser = value_parser!(i64).range(1..),
+        default_value = "86400",
+        value_name = "RATELIMIT_THRESHOLD",
+        env = "RATELIMIT_THRESHOLD",
+        help = "Set upgrade intent ratelimit in seconds: only one upgrade per subgraph within the threshold (default: 86400 seconds = 1 day)"
+    )]
+    pub ratelimit_threshold: i64,
     #[clap(
         long,
         value_parser = value_parser!(i64).range(1..),

--- a/subgraph-radio/src/operator/mod.rs
+++ b/subgraph-radio/src/operator/mod.rs
@@ -473,7 +473,13 @@ pub async fn process_message(
                 VALIDATED_MESSAGES
                     .with_label_values(&[&msg.identifier, "upgrade_intent_message"])
                     .inc();
-                radio_msg.process_valid_message(&config, &notifier).await;
+                if radio_msg
+                    .process_valid_message(&config, &notifier, &state)
+                    .await
+                    .is_ok()
+                {
+                    state.add_upgrade_intent_message(msg.clone());
+                };
             };
         } else {
             trace!("Waku message not decoded or validated, skipped message",);

--- a/test-utils/src/config.rs
+++ b/test-utils/src/config.rs
@@ -57,6 +57,7 @@ pub fn test_config() -> Config {
                 graphcast_network: GraphcastNetworkName::Testnet,
                 topics: vec![],
                 coverage: CoverageLevel::OnChain,
+                ratelimit_threshold: 60000,
                 collect_message_duration: 60,
                 log_level:
                     "off,hyper=off,graphcast_sdk=trace,subgraph_radio=trace,test_runner=trace"


### PR DESCRIPTION
### Description

- Persist a HashMap of upgrade intent messages - require unique subgraph id
- When operator receives an ui msg, check the hashmap for the subgraph id
  - if there's no existing record, add msg to the hashmap and offchain sync
  - if there's existing record, check for the existing nonce. Do nothing if there has been a recent upgrade, otherwise replace the old message and offchain sync
- Added Http service with optional subgraph_id filter
- No explicit cleaning as only 1 message per topic is permitted

### Issue link (if applicable)

Resolves https://github.com/graphops/subgraph-radio/issues/25
Resolves https://github.com/graphops/subgraph-radio/issues/40


### Checklist
- [x] Are tests up-to-date with the new changes? 
- [ ] Are docs up-to-date with the new changes? (Open PR on docs repo if necessary)
