### PR TITLE
fix: add local attestation without matching with remote

### DIFF
--- a/subgraph-radio/src/operator/attestation.rs
+++ b/subgraph-radio/src/operator/attestation.rs
@@ -1056,11 +1056,6 @@ mod tests {
         let mut local_attestations: HashMap<String, HashMap<u64, Attestation>> = HashMap::new();
         local_attestations.insert("hash".to_string(), local_blocks.clone());
         local_attestations.insert("hash2".to_string(), local_blocks);
-        println!(
-            "find local comparison point: {:#?}\n{:#?}",
-            &local_attestations,
-            &test_msg_vec()
-        );
         let (block_num, collect_window_end) = local_comparison_point(
             &local_attestations,
             &test_msg_vec(),


### PR DESCRIPTION
### Description

- ratio string always include local attestation. If there is a local attestation without matching with an existing attestation, indicate with "1*" ("{local_stake}*" for stake ratio) at the end. If there is no local attestation, explicitly mark with "0*" at the end. 
- tests

### Issue link (if applicable)

### Checklist
- [x] Are tests up-to-date with the new changes? 
- [ ] Are docs up-to-date with the new changes? (Open PR on docs repo if necessary)
