### PR TITLE
Fix: comparison and metrics

### DIFF
--- a/subgraph-radio/src/messages/poi.rs
+++ b/subgraph-radio/src/messages/poi.rs
@@ -241,10 +241,6 @@ pub async fn send_poi_message(
     {
         Ok(content) => {
             let nonce = Utc::now().timestamp();
-            let block_hash = callbook
-                .block_hash(&network_name.to_string(), message_block)
-                .await
-                .map_err(OperationError::Query)?;
             let radio_message = PublicPoiMessage::build(
                 id.clone(),
                 content.clone(),
@@ -339,10 +335,10 @@ pub async fn poi_message_comparison(
         }
         _ => {
             let err_msg = format!(
-                "Deployment {} comparison not triggered: no matching attestation to compare",
+                "Deployment {} comparison not triggered: no local attestation to compare",
                 id.clone()
             );
-            debug!(err = err_msg, "No matching attestations",);
+            debug!(err = err_msg, "No local attestations for comparison",);
             return Err(OperationError::CompareTrigger(id.clone(), 0, err_msg));
         }
     };

--- a/subgraph-radio/src/operator/mod.rs
+++ b/subgraph-radio/src/operator/mod.rs
@@ -185,7 +185,7 @@ impl RadioOperator {
             self.config.radio_infrastructure.topic_update_interval,
         ));
 
-        let mut state_update_interval = interval(Duration::from_secs(60));
+        let mut state_update_interval = interval(Duration::from_secs(10));
         let mut gossip_poi_interval = interval(Duration::from_secs(30));
         let mut comparison_interval = interval(Duration::from_secs(30));
 
@@ -224,9 +224,6 @@ impl RadioOperator {
                             &self.config.graph_stack().indexer_address).await)
                     ).await;
 
-                    // Update the number of peers connected
-                    CONNECTED_PEERS.set(connected_peer_count(&self.graphcast_agent().node_handle).unwrap_or_default().try_into().unwrap_or_default());
-                    GOSSIP_PEERS.set(self.graphcast_agent.number_of_peers().try_into().unwrap_or_default());
                     if result.is_err() {
                         warn!("update_content_topics timed out");
                     } else {
@@ -238,6 +235,9 @@ impl RadioOperator {
                         skip_iteration.store(false, Ordering::SeqCst);
                         continue;
                     }
+                    // Update the number of peers connected
+                    CONNECTED_PEERS.set(connected_peer_count(&self.graphcast_agent().node_handle).unwrap_or_default().try_into().unwrap_or_default());
+                    GOSSIP_PEERS.set(self.graphcast_agent.number_of_peers().try_into().unwrap_or_default());
 
                     // Save cache if path provided
                     let _ = &self.config.radio_infrastructure().persistence_file_path.as_ref().map(|path| {


### PR DESCRIPTION
### Description

Proposing a fix on metrics fluctuation and frequent comparison notifications.

- Repositioned the metrics recording for active indexers and cached public poi messages
- Reviewed and modified the notifications logic such that NotFound changes should not be sent to the users
- Investigated the reason for frequent fluctuations, identified a potential issue of event intervals, thus increased the comparison interval (from 30 seconds to 1 minute, although comparison block interval on networks are estimated to be 5 minutes)
- Removed some redundant code on validation

### Issue link (if applicable)

Fixes #71

### Checklist
- [ ] Are tests up-to-date with the new changes? 
- [x] Are docs up-to-date with the new changes? (Open PR on docs repo if necessary)
