### PR TITLE
fix: remove local_ppois_to_compare, refactor diverged_subgraphs

### DIFF
--- a/subgraph-radio/src/metrics/mod.rs
+++ b/subgraph-radio/src/metrics/mod.rs
@@ -114,23 +114,6 @@ pub static RECEIVED_MESSAGES: Lazy<IntCounter> = Lazy::new(|| {
 });
 
 #[allow(dead_code)]
-pub static LOCAL_PPOIS_TO_COMPARE: Lazy<IntGaugeVec> = Lazy::new(|| {
-    let m = IntGaugeVec::new(
-        Opts::new(
-            "local_ppois_to_compare",
-            "Number of pPOIs stored locally for each subgraph",
-        )
-        .namespace("graphcast")
-        .subsystem("subgraph_radio"),
-        &["deployment"],
-    )
-    .expect("Failed to create LOCAL_PPOIS_TO_COMPARE gauges");
-    prometheus::register(Box::new(m.clone()))
-        .expect("Failed to register local_ppois_to_compare gauge");
-    m
-});
-
-#[allow(dead_code)]
 pub static REGISTRY: Lazy<prometheus::Registry> = Lazy::new(prometheus::Registry::new);
 
 #[allow(dead_code)]
@@ -153,7 +136,6 @@ pub fn start_metrics() {
             Box::new(CONNECTED_PEERS.clone()),
             Box::new(GOSSIP_PEERS.clone()),
             Box::new(RECEIVED_MESSAGES.clone()),
-            Box::new(LOCAL_PPOIS_TO_COMPARE.clone()),
         ],
     );
 }

--- a/subgraph-radio/src/state.rs
+++ b/subgraph-radio/src/state.rs
@@ -144,6 +144,20 @@ impl PersistedState {
             .cloned()
     }
 
+    /// Getter for comparison results with a certain result type
+    pub fn comparison_result_typed(
+        &self,
+        result_type: ComparisonResultType,
+    ) -> Vec<ComparisonResult> {
+        let mut matched_type = vec![];
+        for (_key, value) in self.comparison_results() {
+            if value.result_type == result_type {
+                matched_type.push(value.clone());
+            }
+        }
+        matched_type
+    }
+
     /// Update local_attestations
     pub async fn update_local(&mut self, local_attestations: Local) {
         self.local_attestations = local_attestations;
@@ -720,5 +734,86 @@ mod tests {
                 .new_hash,
             "QmAAfLWowm1xkqc41vcygKNwFUvpsDSMbHdHghxmDVmH9x".to_string()
         );
+    }
+
+    #[test]
+    fn test_comparison_result_typed_not_found() {
+        let mut comparison_results = HashMap::new();
+        comparison_results.insert(
+            "a".to_string(),
+            ComparisonResult {
+                result_type: ComparisonResultType::NotFound,
+                deployment: String::from("Qmhash"),
+                block_number: 100,
+                local_attestation: None,
+                attestations: vec![],
+            },
+        );
+        comparison_results.insert(
+            "b".to_string(),
+            ComparisonResult {
+                result_type: ComparisonResultType::Match,
+                deployment: String::from("Qmhash"),
+                block_number: 100,
+                local_attestation: None,
+                attestations: vec![],
+            },
+        );
+        comparison_results.insert(
+            "c".to_string(),
+            ComparisonResult {
+                result_type: ComparisonResultType::Match,
+                deployment: String::from("Qmhash"),
+                block_number: 100,
+                local_attestation: None,
+                attestations: vec![],
+            },
+        );
+        comparison_results.insert(
+            "d".to_string(),
+            ComparisonResult {
+                result_type: ComparisonResultType::Match,
+                deployment: String::from("Qmhash"),
+                block_number: 100,
+                local_attestation: None,
+                attestations: vec![],
+            },
+        );
+        comparison_results.insert(
+            "e".to_string(),
+            ComparisonResult {
+                result_type: ComparisonResultType::Divergent,
+                deployment: String::from("Qmhash"),
+                block_number: 100,
+                local_attestation: None,
+                attestations: vec![],
+            },
+        );
+        comparison_results.insert(
+            "f".to_string(),
+            ComparisonResult {
+                result_type: ComparisonResultType::NotFound,
+                deployment: String::from("Qmhash"),
+                block_number: 100,
+                local_attestation: None,
+                attestations: vec![],
+            },
+        );
+
+        let state = PersistedState {
+            comparison_results: Arc::new(SyncMutex::new(comparison_results)),
+            local_attestations: Arc::new(SyncMutex::new(HashMap::new())),
+            remote_ppoi_messages: Arc::new(SyncMutex::new(Vec::new())),
+            upgrade_intent_messages: Arc::new(SyncMutex::new(HashMap::new())),
+        };
+
+        let results = state.comparison_result_typed(ComparisonResultType::Match);
+        assert_eq!(results.len(), 3);
+        let results = state.comparison_result_typed(ComparisonResultType::NotFound);
+        assert_eq!(results.len(), 2);
+        let results = state.comparison_result_typed(ComparisonResultType::Divergent);
+        assert_eq!(results.len(), 1);
+        let results = state.comparison_result_typed(ComparisonResultType::BuildFailed);
+        assert_eq!(results.len(), 0);
     }
 }


### PR DESCRIPTION
### Description

Should be a better fix for the metrics

- `local_ppois_to_compare` was recorded at store and delete of local attestations but using the wrong values. The original intention for this metrics is to track the number of public POIs to compare, but this in theory is just the number of deployments being actively crosschecked. This PR deprecate this metrics as it doesn't represent true values of local state, in favor of the existing comparison table
- `diverged_subgraphs` was recorded at each comparison_result interval based on compared results. Some subgraphs have diverged state but considered `notFound` for certain intervals when they are waiting for the new block checkpoint. This PR adds a new function to grab the comparison results of a certain type from the persisted states, instead of relying on a particular comparison interval. This should improve stability of the metrics and better represent the true number of subgraphs with diverged results.

### Issue link (if applicable)

Resolves https://github.com/graphops/subgraph-radio/issues/70

### Checklist
- [x] Are tests up-to-date with the new changes? 
- [ ] Are docs up-to-date with the new changes? (Open PR on docs repo if necessary)
