### PR TITLE
Add divergence summary notification on a given interval

### DIFF
--- a/subgraph-radio/benches/gossips.rs
+++ b/subgraph-radio/benches/gossips.rs
@@ -12,6 +12,7 @@ use std::sync::mpsc;
 use graphcast_sdk::networks::NetworkName;
 use graphcast_sdk::{BlockPointer, GraphcastNetworkName, LogFormat, NetworkPointer, WakuMessage};
 use subgraph_radio::config::{Config, CoverageLevel, GraphStack, RadioInfrastructure, Waku};
+use subgraph_radio::operator::notifier::NotificationMode;
 
 fn gossip_poi_bench(c: &mut Criterion) {
     let identifiers = black_box(vec!["identifier1".to_string(), "identifier2".to_string()]);
@@ -71,6 +72,8 @@ fn gossip_poi_bench(c: &mut Criterion) {
             log_format: LogFormat::Pretty,
             graphcast_network: GraphcastNetworkName::Testnet,
             auto_upgrade: CoverageLevel::Comprehensive,
+            notification_interval: 1,
+            notification_mode: NotificationMode::PeriodicReport,
         },
         config_file: None,
     });

--- a/subgraph-radio/src/config.rs
+++ b/subgraph-radio/src/config.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use tracing::{debug, info, trace};
 
+use crate::operator::notifier::NotificationMode;
 use crate::state::{panic_hook, PersistedState};
 use crate::{active_allocation_hashes, syncing_deployment_hashes};
 
@@ -153,7 +154,7 @@ impl Config {
             state
         } else {
             debug!("Created new state");
-            PersistedState::new(None, None, None, None)
+            PersistedState::new(None, None, None, None, None)
         }
     }
 
@@ -470,11 +471,28 @@ pub struct RadioInfrastructure {
         long,
         value_name = "LOG_FORMAT",
         env = "LOG_FORMAT",
-        help = "Support logging formats: pretty, json, full, compact",
-        long_help = "pretty: verbose and human readable; json: not verbose and parsable; compact:  not verbose and not parsable; full: verbose and not parsible",
+        help = "Supported logging formats: pretty, json, full, compact",
+        long_help = "pretty: verbose and human readable; json: not verbose and parsable; compact:  not verbose and not parsable; full: verbose and not parseable",
         default_value = "pretty"
     )]
     pub log_format: LogFormat,
+    #[clap(
+        long,
+        value_name = "NOTIFICATION_MODE",
+        env = "NOTIFICATION_MODE",
+        help = "Supported: live, periodic-report, periodic-update",
+        long_help = "live: send a notification as soon as it finds a divergence; periodic-report: send a notification on a specified interval (default is 24 hours but can be configured with the NOTIFICATION_INTERVAL variable) with a summary and a list of divergent subgraphs; periodic-update: send a notification on a specified interval (default is 24 hours but can be configured with the NOTIFICATION_INTERVAL variable) containing updates since the previous notification",
+        default_value = "live"
+    )]
+    pub notification_mode: NotificationMode,
+    #[clap(
+        long,
+        value_name = "NOTIFICATION_INTERVAL",
+        env = "NOTIFICATION_INTERVAL",
+        help = "Interval (in hours) between sending a divergence summary notification",
+        default_value = "24"
+    )]
+    pub notification_interval: u64,
 }
 
 #[derive(Clone, Debug, Args, Serialize, Deserialize, Default)]
@@ -613,6 +631,8 @@ mod tests {
                 log_format: LogFormat::Pretty,
                 graphcast_network: GraphcastNetworkName::Testnet,
                 auto_upgrade: CoverageLevel::Comprehensive,
+                notification_mode: NotificationMode::Live,
+                notification_interval: 24,
             },
             config_file: None,
         }

--- a/subgraph-radio/src/messages/upgrade.rs
+++ b/subgraph-radio/src/messages/upgrade.rs
@@ -4,6 +4,7 @@ use ethers_core::types::transaction::eip712::Eip712;
 use ethers_derive_eip712::*;
 use prost::Message;
 use serde::{Deserialize, Serialize};
+
 use tracing::{debug, info};
 
 use graphcast_sdk::{

--- a/subgraph-radio/src/operator/notifier.rs
+++ b/subgraph-radio/src/operator/notifier.rs
@@ -14,9 +14,20 @@ pub struct Notifier {
     discord_webhook: Option<String>,
     telegram_token: Option<String>,
     telegram_chat_id: Option<i64>,
+    pub notification_mode: NotificationMode,
+    pub notification_interval: u64,
+}
+
+#[derive(clap::ValueEnum, Clone, Debug, Serialize, Deserialize, Default, PartialEq)]
+pub enum NotificationMode {
+    PeriodicReport,
+    PeriodicUpdate,
+    #[default]
+    Live,
 }
 
 impl Notifier {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         radio_name: String,
         slack_token: Option<String>,
@@ -24,6 +35,8 @@ impl Notifier {
         discord_webhook: Option<String>,
         telegram_token: Option<String>,
         telegram_chat_id: Option<i64>,
+        notification_mode: NotificationMode,
+        notification_interval: u64,
     ) -> Notifier {
         Notifier {
             radio_name,
@@ -32,6 +45,8 @@ impl Notifier {
             discord_webhook,
             telegram_token,
             telegram_chat_id,
+            notification_mode,
+            notification_interval,
         }
     }
 
@@ -42,6 +57,8 @@ impl Notifier {
         let discord_webhook = config.radio_infrastructure().discord_webhook.clone();
         let telegram_token = config.radio_infrastructure().telegram_token.clone();
         let telegram_chat_id = config.radio_infrastructure().telegram_chat_id;
+        let notification_mode = config.radio_infrastructure().notification_mode.clone();
+        let notification_interval = config.radio_infrastructure().notification_interval;
 
         Notifier::new(
             radio_name,
@@ -50,6 +67,8 @@ impl Notifier {
             discord_webhook,
             telegram_token,
             telegram_chat_id,
+            notification_mode,
+            notification_interval,
         )
     }
 

--- a/subgraph-radio/src/server/model/mod.rs
+++ b/subgraph-radio/src/server/model/mod.rs
@@ -241,8 +241,8 @@ impl SubgraphRadioContext {
         let msgs = self.remote_ppoi_messages();
         let filtered = msgs
             .iter()
+            .filter(|&message| filter_remote_ppoi_messages(message, identifier, block))
             .cloned()
-            .filter(|message| filter_remote_ppoi_messages(message, identifier, block))
             .collect::<Vec<_>>();
         filtered
     }

--- a/test-utils/src/config.rs
+++ b/test-utils/src/config.rs
@@ -4,6 +4,7 @@ use graphcast_sdk::{
 };
 use serde::{Deserialize, Serialize};
 use subgraph_radio::config::{Config, CoverageLevel, GraphStack, RadioInfrastructure, Waku};
+use subgraph_radio::operator::notifier::NotificationMode;
 
 #[derive(Clone, Debug, Parser, Serialize, Deserialize)]
 #[clap(name = "test-sender", about = "Mock message sender")]
@@ -78,6 +79,8 @@ pub fn test_config() -> Config {
                 id_validation: IdentityValidation::ValidAddress,
                 topic_update_interval: 600,
                 auto_upgrade: CoverageLevel::OnChain,
+                notification_mode: NotificationMode::Live,
+                notification_interval: 24,
             }
         },
         config_file: None,


### PR DESCRIPTION
- [x] Added `NOTIFICATION_MODE` config var, supports `live`, `periodic-report` and `periodic-update` options, live being the current functionality, periodic-report sending a summary of all divergences on a given interval and periodic-update accumulates the notifications that live would send, but sends them at a given interval (both periodic options can be configured with the new `NOTIFICATION_INTERVAL`, default is 24 every hours)
- [x] Added another tick (`notification_interval`) in tokio::select to facilitate the new daily action if `NOTIFICATION_MODE=periodic_report`
- [x] Added condition for sending divergence notifications when a divergence is caught, based on `NOTIFICATION_MODE`
- [x] Aggregated the live notifications such that they're sent in a batch message, instead of each one being sent as a separate message