### PR TITLE
feat: peerData, localPeerData GraphQL APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2342,8 +2342,7 @@ dependencies = [
 [[package]]
 name = "graphcast-sdk"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1c78f4696a06aec5dcb8d9aafa15e2f55482629540c7b8c70ff423ec279ca67"
+source = "git+https://github.com/graphops/graphcast-sdk?branch=hope/peer-helpers#de519bd80914397ab984fb6b6c0ee7058d5c0da0"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2342,7 +2342,7 @@ dependencies = [
 [[package]]
 name = "graphcast-sdk"
 version = "0.5.0"
-source = "git+https://github.com/graphops/graphcast-sdk?branch=hope/peer-helpers#de519bd80914397ab984fb6b6c0ee7058d5c0da0"
+source = "git+https://github.com/graphops/graphcast-sdk#0f89833e0e6b57a9d2b40a9f742fd697573114f1"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -6030,9 +6030,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "waku-bindings"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c52764c1cde43ad4e233ad23b18bbba11f9179a6a4e9b60c660d4f22450289"
+checksum = "2db391df1457690eb489ce20fdcc7ba5d1fd6c24feee3a5942ce51273c71e514"
 dependencies = [
  "aes-gcm",
  "base64 0.21.4",
@@ -6052,9 +6052,9 @@ dependencies = [
 
 [[package]]
 name = "waku-sys"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23174a6c97644142b87cfb11e1b80b972a1d79b9260ec8ad2896775cbd45a99"
+checksum = "31f010dd1ed719eacb7b7a7dc26e39cc285f9f006cfd0147af90ae2695136556"
 dependencies = [
  "bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ panic = 'unwind'
 opt-level = 3
 
 [workspace.dependencies]
-graphcast-sdk = "0.5.0"
+graphcast-sdk = { git = "https://github.com/graphops/graphcast-sdk", branch = "hope/peer-helpers" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ panic = 'unwind'
 opt-level = 3
 
 [workspace.dependencies]
-graphcast-sdk = { git = "https://github.com/graphops/graphcast-sdk", branch = "hope/peer-helpers" }
+graphcast-sdk = { git = "https://github.com/graphops/graphcast-sdk" }

--- a/subgraph-radio/src/config.rs
+++ b/subgraph-radio/src/config.rs
@@ -100,7 +100,7 @@ impl Config {
     ) -> Result<GraphcastAgentConfig, GraphcastAgentError> {
         let wallet_key = self.wallet_input().unwrap().to_string();
         let topics = self.radio_infrastructure().topics.clone();
-        let mut discv5_enrs = self.waku().discv5_enrs.clone().unwrap_or(vec![]);
+        let mut discv5_enrs = self.waku().discv5_enrs.clone().unwrap_or_default();
         // Discovery network
         discv5_enrs.push("enr:-P-4QJI8tS1WTdIQxq_yIrD05oIIW1Xg-tm_qfP0CHfJGnp9dfr6ttQJmHwTNxGEl4Le8Q7YHcmi-kXTtphxFysS11oBgmlkgnY0gmlwhLymh5GKbXVsdGlhZGRyc7hgAC02KG5vZGUtMDEuZG8tYW1zMy53YWt1djIucHJvZC5zdGF0dXNpbS5uZXQGdl8ALzYobm9kZS0wMS5kby1hbXMzLndha3V2Mi5wcm9kLnN0YXR1c2ltLm5ldAYfQN4DiXNlY3AyNTZrMaEDbl1X_zJIw3EAJGtmHMVn4Z2xhpSoUaP5ElsHKCv7hlWDdGNwgnZfg3VkcIIjKIV3YWt1Mg8".to_string());
 

--- a/subgraph-radio/src/server/mod.rs
+++ b/subgraph-radio/src/server/mod.rs
@@ -1,5 +1,6 @@
 use axum::{extract::Extension, routing::get, Router};
 use axum_server::Handle;
+use graphcast_sdk::graphcast_agent::GraphcastAgent;
 use std::net::SocketAddr;
 use std::str::FromStr;
 
@@ -22,12 +23,21 @@ pub mod routes;
 /// Set up the routes for a radio health endpoint at `/health`
 /// and a versioned GraphQL endpoint at `api/v1/graphql`
 /// This function starts a API server at the configured server_host and server_port
-pub async fn run_server(config: Config, persisted_state: &'static PersistedState, handle: Handle) {
+pub async fn run_server(
+    config: Config,
+    persisted_state: &'static PersistedState,
+    graphcast_agent: &'static GraphcastAgent,
+    handle: Handle,
+) {
     if config.radio_infrastructure().server_port.is_none() {
         return;
     }
     let port = config.radio_infrastructure().server_port.unwrap();
-    let context = Arc::new(SubgraphRadioContext::init(config.clone(), persisted_state));
+    let context = Arc::new(SubgraphRadioContext::init(
+        config.clone(),
+        persisted_state,
+        graphcast_agent,
+    ));
 
     let schema = build_schema(Arc::clone(&context)).await;
 

--- a/subgraph-radio/src/state.rs
+++ b/subgraph-radio/src/state.rs
@@ -29,7 +29,6 @@ type Local = Arc<SyncMutex<HashMap<String, HashMap<u64, Attestation>>>>;
 type Remote = Arc<SyncMutex<Vec<GraphcastMessage<PublicPoiMessage>>>>;
 type UpgradeMessages = Arc<SyncMutex<HashMap<String, GraphcastMessage<UpgradeIntentMessage>>>>;
 type ComparisonResults = Arc<SyncMutex<HashMap<String, ComparisonResult>>>;
-
 type Notifications = Arc<SyncMutex<HashMap<String, String>>>;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/test-runner/Cargo.toml
+++ b/test-runner/Cargo.toml
@@ -21,7 +21,7 @@ categories = [
 ]
 
 [dependencies]
-waku = { version = "0.3.0", package = "waku-bindings" }
+waku = { version = "0.4.0", package = "waku-bindings" }
 test-utils = { path = "../test-utils" }
 graphcast-sdk = { workspace = true }
 subgraph-radio = { path = "../subgraph-radio" }

--- a/test-sender/Cargo.toml
+++ b/test-sender/Cargo.toml
@@ -21,7 +21,7 @@ categories = [
 ]
 
 [dependencies]
-waku = { version = "0.3.0", package = "waku-bindings" }
+waku = { version = "0.4.0", package = "waku-bindings" }
 graphcast-sdk = { workspace = true }
 test-utils = { path = "../test-utils" }
 subgraph-radio = { path = "../subgraph-radio" }

--- a/test-sender/src/main.rs
+++ b/test-sender/src/main.rs
@@ -8,15 +8,13 @@ use graphcast_sdk::{
     },
     init_tracing,
     networks::NetworkName,
-    wallet_address,
+    wallet_address, WakuPubSubTopic,
 };
 use std::{net::IpAddr, str::FromStr, thread::sleep, time::Duration};
 use subgraph_radio::messages::poi::PublicPoiMessage;
 use test_utils::{config::TestSenderConfig, dummy_msg::DummyMsg, find_random_udp_port};
 use tracing::{error, info};
-use waku::{
-    waku_new, GossipSubParams, ProtocolId, WakuContentTopic, WakuNodeConfig, WakuPubSubTopic,
-};
+use waku::{waku_new, GossipSubParams, ProtocolId, WakuContentTopic, WakuNodeConfig};
 
 async fn start_sender(config: TestSenderConfig) {
     std::env::set_var(

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -21,7 +21,7 @@ categories = [
 ]
 
 [dependencies]
-waku = { version = "0.3.0", package = "waku-bindings" }
+waku = { version = "0.4.0", package = "waku-bindings" }
 graphcast-sdk = { workspace = true }
 subgraph-radio = { path = "../subgraph-radio" }
 tokio = { version = "1.1.1", features = ["full", "rt"] }


### PR DESCRIPTION
### Description

- Added GraphQL APIs to expose gossip peer information
- Added GraphcastAgent to Server context, considered storing peer info to PersistedState but left for future considerations
- Tested locally
<img width="1428" alt="Screenshot 2023-10-26 at 4 31 25 PM" src="https://github.com/graphops/subgraph-radio/assets/60078528/8d961aa2-b9dd-4b8c-8a0b-fcef26256f64">

### Issue link (if applicable)

Resolves https://github.com/graphops/subgraph-radio/issues/106

### Checklist
- [ ] Are tests up-to-date with the new changes? 
- [ ] Are docs up-to-date with the new changes? (Open PR on docs repo if necessary)
