### PR TITLE
refactor: use radio payload trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2349,7 +2349,8 @@ dependencies = [
 
 [[package]]
 name = "graphcast-sdk"
-version = "0.5.1"
+version = "0.5.2"
+source = "git+https://github.com/graphops/graphcast-sdk#f4e50547df85bff002023c759f4330c41f0c1ee3"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2350,8 +2350,6 @@ dependencies = [
 [[package]]
 name = "graphcast-sdk"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e50bbbda85f0d64f962712cfd48801ff53d9b7e7f09583dce2cd23a8ea6c5645"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,4 @@ panic = 'unwind'
 opt-level = 3
 
 [workspace.dependencies]
-# graphcast-sdk = "0.5.1"
-graphcast-sdk = { path = "../graphcast-rs" }
+graphcast-sdk = { git = "https://github.com/graphops/graphcast-sdk" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,5 @@ panic = 'unwind'
 opt-level = 3
 
 [workspace.dependencies]
-graphcast-sdk = "0.5.1"
+# graphcast-sdk = "0.5.1"
+graphcast-sdk = { path = "../graphcast-rs" }

--- a/subgraph-radio/src/lib.rs
+++ b/subgraph-radio/src/lib.rs
@@ -215,7 +215,7 @@ impl ControlFlow {
 #[cfg(test)]
 mod tests {
     use crate::messages::poi::PublicPoiMessage;
-    use graphcast_sdk::graphcast_agent::message_typing::GraphcastMessage;
+    use graphcast_sdk::graphcast_agent::message_typing::{GraphcastMessage, RadioPayload};
 
     fn simple_message() -> PublicPoiMessage {
         PublicPoiMessage::new(

--- a/subgraph-radio/src/messages/poi.rs
+++ b/subgraph-radio/src/messages/poi.rs
@@ -6,7 +6,7 @@ use ethers_core::types::transaction::eip712::Eip712;
 use ethers_derive_eip712::*;
 use graphcast_sdk::callbook::CallBook;
 use graphcast_sdk::{
-    graphcast_agent::message_typing::{MessageError, GraphcastMessage, RadioPayload},
+    graphcast_agent::message_typing::{GraphcastMessage, MessageError, RadioPayload},
     graphql::client_graph_node::query_graph_node_network_block_hash,
     networks::NetworkName,
 };

--- a/subgraph-radio/src/messages/upgrade.rs
+++ b/subgraph-radio/src/messages/upgrade.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{debug, info};
 
 use graphcast_sdk::{
-    graphcast_agent::message_typing::{MessageError, GraphcastMessage, RadioPayload},
+    graphcast_agent::message_typing::{GraphcastMessage, MessageError, RadioPayload},
     graphql::client_graph_account::{owned_subgraphs, subgraph_hash_by_id},
 };
 
@@ -57,7 +57,6 @@ impl RadioPayload for UpgradeIntentMessage {
 }
 
 impl UpgradeIntentMessage {
-
     /// Check message from valid sender: check for ownership for subgraph-owner messages
     pub async fn valid_owner(&self, network_subgraph: &str) -> Result<&Self, MessageError> {
         let subgraphs = owned_subgraphs(network_subgraph, &self.graph_account)

--- a/subgraph-radio/src/operator/attestation.rs
+++ b/subgraph-radio/src/operator/attestation.rs
@@ -14,7 +14,7 @@ use tracing::{debug, error, info, trace, warn};
 
 use graphcast_sdk::{
     callbook::CallBook,
-    graphcast_agent::message_typing::{get_indexer_stake, MessageError, GraphcastMessage},
+    graphcast_agent::message_typing::{get_indexer_stake, GraphcastMessage, MessageError},
 };
 
 use crate::operator::notifier::NotificationMode;
@@ -126,9 +126,7 @@ pub async fn process_ppoi_message(
         let sender_stake =
             get_indexer_stake(&radio_msg.graph_account.clone(), callbook.graph_network())
                 .await
-                .map_err(|e| {
-                    AttestationError::BuildError(MessageError::FieldDerivations(e))
-                })?;
+                .map_err(|e| AttestationError::BuildError(MessageError::FieldDerivations(e)))?;
 
         //TODO: update this to utilize update_blocks?
         let blocks = remote_attestations

--- a/subgraph-radio/src/operator/attestation.rs
+++ b/subgraph-radio/src/operator/attestation.rs
@@ -14,7 +14,7 @@ use tracing::{debug, error, info, trace, warn};
 
 use graphcast_sdk::{
     callbook::CallBook,
-    graphcast_agent::message_typing::{get_indexer_stake, BuildMessageError, GraphcastMessage},
+    graphcast_agent::message_typing::{get_indexer_stake, MessageError, GraphcastMessage},
 };
 
 use crate::operator::notifier::NotificationMode;
@@ -127,7 +127,7 @@ pub async fn process_ppoi_message(
             get_indexer_stake(&radio_msg.graph_account.clone(), callbook.graph_network())
                 .await
                 .map_err(|e| {
-                    AttestationError::BuildError(BuildMessageError::FieldDerivations(e))
+                    AttestationError::BuildError(MessageError::FieldDerivations(e))
                 })?;
 
         //TODO: update this to utilize update_blocks?
@@ -672,7 +672,7 @@ pub async fn process_comparison_results(
 #[derive(Debug, thiserror::Error)]
 pub enum AttestationError {
     #[error("Failed to build attestation: {0}")]
-    BuildError(BuildMessageError),
+    BuildError(MessageError),
     #[error("Failed to update attestation: {0}")]
     UpdateError(String),
 }

--- a/subgraph-radio/src/operator/operation.rs
+++ b/subgraph-radio/src/operator/operation.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use tracing::{debug, trace, warn};
 
 use graphcast_sdk::{
-    determine_message_block, graphcast_agent::message_typing::BuildMessageError,
+    determine_message_block, graphcast_agent::message_typing::MessageError,
     networks::NetworkName, BlockPointer, NetworkBlockError, NetworkPointer,
 };
 
@@ -23,7 +23,7 @@ pub async fn gossip_set_up(
     id: String,
     network_chainhead_blocks: &HashMap<NetworkName, BlockPointer>,
     subgraph_network_latest_blocks: &HashMap<String, NetworkPointer>,
-) -> Result<(NetworkName, BlockPointer, u64), BuildMessageError> {
+) -> Result<(NetworkName, BlockPointer, u64), MessageError> {
     // Get the indexing network of the deployment
     // and update the NETWORK message block
     let (network_name, latest_block) = match subgraph_network_latest_blocks.get(&id.clone()) {
@@ -37,7 +37,7 @@ pub async fn gossip_set_up(
                 err = tracing::field::debug(&err_msg),
                 "Failed to build message"
             );
-            return Err(BuildMessageError::Network(NetworkBlockError::FailedStatus(
+            return Err(MessageError::Network(NetworkBlockError::FailedStatus(
                 err_msg,
             )));
         }
@@ -45,7 +45,7 @@ pub async fn gossip_set_up(
 
     let message_block = match determine_message_block(network_chainhead_blocks, network_name) {
         Ok(block) => block,
-        Err(e) => return Err(BuildMessageError::Network(e)),
+        Err(e) => return Err(MessageError::Network(e)),
     };
 
     debug!(

--- a/subgraph-radio/src/operator/operation.rs
+++ b/subgraph-radio/src/operator/operation.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 use tracing::{debug, trace, warn};
 
 use graphcast_sdk::{
-    determine_message_block, graphcast_agent::message_typing::MessageError,
-    networks::NetworkName, BlockPointer, NetworkBlockError, NetworkPointer,
+    determine_message_block, graphcast_agent::message_typing::MessageError, networks::NetworkName,
+    BlockPointer, NetworkBlockError, NetworkPointer,
 };
 
 use crate::messages::poi::{poi_message_comparison, send_poi_message};

--- a/test-utils/src/dummy_msg.rs
+++ b/test-utils/src/dummy_msg.rs
@@ -2,9 +2,11 @@ use async_graphql::SimpleObject;
 use ethers_contract::EthAbiType;
 use ethers_core::types::transaction::eip712::Eip712;
 use ethers_derive_eip712::*;
+use graphcast_sdk::graphcast_agent::message_typing::{
+    GraphcastMessage, MessageError, RadioPayload,
+};
 use prost::Message;
 use serde::{Deserialize, Serialize};
-use graphcast_sdk::graphcast_agent::message_typing::{RadioPayload, GraphcastMessage, MessageError};
 
 #[derive(Eip712, EthAbiType, Clone, Message, Serialize, Deserialize, SimpleObject)]
 #[eip712(
@@ -22,7 +24,7 @@ pub struct DummyMsg {
 
 impl RadioPayload for DummyMsg {
     fn valid_outer(&self, outer: &GraphcastMessage<Self>) -> Result<&Self, MessageError> {
-        if self.identifier == outer.identifier{
+        if self.identifier == outer.identifier {
             Ok(self)
         } else {
             Err(MessageError::Payload)

--- a/test-utils/src/dummy_msg.rs
+++ b/test-utils/src/dummy_msg.rs
@@ -4,6 +4,7 @@ use ethers_core::types::transaction::eip712::Eip712;
 use ethers_derive_eip712::*;
 use prost::Message;
 use serde::{Deserialize, Serialize};
+use graphcast_sdk::graphcast_agent::message_typing::{RadioPayload, GraphcastMessage, MessageError};
 
 #[derive(Eip712, EthAbiType, Clone, Message, Serialize, Deserialize, SimpleObject)]
 #[eip712(
@@ -17,6 +18,16 @@ pub struct DummyMsg {
     pub identifier: String,
     #[prost(int32, tag = "2")]
     pub dummy_value: i32,
+}
+
+impl RadioPayload for DummyMsg {
+    fn valid_outer(&self, outer: &GraphcastMessage<Self>) -> Result<&Self, MessageError> {
+        if self.identifier == outer.identifier{
+            Ok(self)
+        } else {
+            Err(MessageError::Payload)
+        }
+    }
 }
 
 impl DummyMsg {

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -9,10 +9,9 @@ use std::{
 };
 
 use config::TestSenderConfig;
-use graphcast_sdk::graphcast_agent::message_typing::GraphcastMessage;
-use graphcast_sdk::graphcast_agent::message_typing::IdentityValidation;
+use graphcast_sdk::graphcast_agent::message_typing::{GraphcastMessage, RadioPayload, IdentityValidation};
 use mock_server::{start_mock_server, ServerState};
-use prost::Message;
+
 use rand::Rng;
 use subgraph_radio::{
     config::{Config, CoverageLevel},
@@ -285,12 +284,7 @@ pub fn find_random_udp_port() -> u16 {
 
 pub fn messages_are_equal<T>(msg1: &GraphcastMessage<T>, msg2: &GraphcastMessage<T>) -> bool
 where
-    T: Message
-        + ethers::types::transaction::eip712::Eip712
-        + Default
-        + Clone
-        + 'static
-        + async_graphql::OutputType,
+    T: RadioPayload,
 {
     msg1.identifier == msg2.identifier
         && msg1.nonce == msg2.nonce

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -9,7 +9,9 @@ use std::{
 };
 
 use config::TestSenderConfig;
-use graphcast_sdk::graphcast_agent::message_typing::{GraphcastMessage, RadioPayload, IdentityValidation};
+use graphcast_sdk::graphcast_agent::message_typing::{
+    GraphcastMessage, IdentityValidation, RadioPayload,
+};
 use mock_server::{start_mock_server, ServerState};
 
 use rand::Rng;


### PR DESCRIPTION
### Description

Depends on https://github.com/graphops/graphcast-sdk/pull/303

- utilize radio payload trait
- added TypedMessage enum for supported message types for the radio, added helper function to help determine the type from `WakuMessage` to `GraphcastMessage<SpecificType>`

### Issue link (if applicable)



### Checklist
- [ ] Are tests up-to-date with the new changes? 
- [ ] Are docs up-to-date with the new changes? (Open PR on docs repo if necessary)
