### PR TITLE
Indexer address validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7152,9 +7152,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.27"
+version = "0.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb877ca3232bec99a6472ed63f7241de2a250165260908b2d24c09d867907a85"
+checksum = "6c830786f7720c2fd27a1a0e27a709dbd3c4d009b56d098fc742d4f4eab91fe2"
 dependencies = [
  "memchr",
 ]

--- a/subgraph-radio/src/operator/mod.rs
+++ b/subgraph-radio/src/operator/mod.rs
@@ -97,6 +97,8 @@ impl RadioOperator {
         debug!("Set global static instance of graphcast_agent");
         _ = GRAPHCAST_AGENT.set(graphcast_agent.clone());
 
+        config.validate_indexer_address().await;
+
         //TODO: Refactor indexer management server validation to SDK, similar to graph node status endpoint
         if let Some(url) = &config.graph_stack.indexer_management_server_endpoint {
             _ = health_query(url)


### PR DESCRIPTION
- [x] `INDEXER_ADDRESS` checked for being a valid eth address
- [x] `INDEXER_ADDRESS` checked against graphcast registry and network subgraph, also making sure that provided `MNEMONIC`/`PRIVATE_KEY` is actually tied to the provided `INDEXER_ADDRESS`

Resolves https://github.com/graphops/subgraph-radio/issues/78