### PR TITLE
Remove waku discovery enr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2190,9 +2190,9 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "eyre"
-version = "0.6.10"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bbb8258be8305fb0237d7b295f47bb24ff1b136a535f473baf40e70468515aa"
+checksum = "80f656be11ddf91bd709454d15d5bd896fbaf4cc3314e69349e4d1569f5b46cd"
 dependencies = [
  "indenter",
  "once_cell",
@@ -2513,7 +2513,7 @@ dependencies = [
 [[package]]
 name = "graphcast-sdk"
 version = "0.5.2"
-source = "git+https://github.com/graphops/graphcast-sdk#01b60ee81ffcddd80cac2e34be259477a388dc1e"
+source = "git+https://github.com/graphops/graphcast-sdk#cc3575768d80d39bb028e208e99e4b9d785b1c16"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/subgraph-radio/src/config.rs
+++ b/subgraph-radio/src/config.rs
@@ -146,9 +146,6 @@ impl Config {
     ) -> Result<GraphcastAgentConfig, GraphcastAgentError> {
         let wallet_key = self.wallet_input().unwrap().to_string();
         let topics = self.radio_setup().topics.clone();
-        let mut discv5_enrs = self.waku().discv5_enrs.clone().unwrap_or_default();
-        // Discovery network
-        discv5_enrs.push("enr:-P-4QJI8tS1WTdIQxq_yIrD05oIIW1Xg-tm_qfP0CHfJGnp9dfr6ttQJmHwTNxGEl4Le8Q7YHcmi-kXTtphxFysS11oBgmlkgnY0gmlwhLymh5GKbXVsdGlhZGRyc7hgAC02KG5vZGUtMDEuZG8tYW1zMy53YWt1djIucHJvZC5zdGF0dXNpbS5uZXQGdl8ALzYobm9kZS0wMS5kby1hbXMzLndha3V2Mi5wcm9kLnN0YXR1c2ltLm5ldAYfQN4DiXNlY3AyNTZrMaEDbl1X_zJIw3EAJGtmHMVn4Z2xhpSoUaP5ElsHKCv7hlWDdGNwgnZfg3VkcIIjKIV3YWt1Mg8".to_string());
 
         GraphcastAgentConfig::new(
             wallet_key,
@@ -166,7 +163,7 @@ impl Config {
             self.waku().waku_port.clone(),
             self.waku().waku_addr.clone(),
             self.waku().filter_protocol,
-            Some(discv5_enrs),
+            self.waku().discv5_enrs.clone(),
             self.waku().discv5_port,
         )
         .await


### PR DESCRIPTION
Bringing the Waku discovery ENR back to the SDK, it will be used if the `discv5_port` config variable is provided.
Accompanying PR - https://github.com/graphops/graphcast-sdk/pull/311