### PR TITLE
Use slack bot with webhook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2513,7 +2513,7 @@ dependencies = [
 [[package]]
 name = "graphcast-sdk"
 version = "0.5.2"
-source = "git+https://github.com/graphops/graphcast-sdk#cc3575768d80d39bb028e208e99e4b9d785b1c16"
+source = "git+https://github.com/graphops/graphcast-sdk#3f4d61cdf2eb81fc61e0fb9fc52b3942688419e3"
 dependencies = [
  "anyhow",
  "async-graphql",

--- a/subgraph-radio/src/config.rs
+++ b/subgraph-radio/src/config.rs
@@ -384,18 +384,11 @@ pub struct RadioSetup {
     pub collect_message_duration: u64,
     #[clap(
         long,
-        value_name = "SLACK_TOKEN",
-        help = "Slack bot API token",
-        env = "SLACK_TOKEN"
+        value_name = "SLACK_WEBHOOK",
+        help = "Slack webhook URL to send messags to",
+        env = "SLACK_WEBHOOK"
     )]
-    pub slack_token: Option<String>,
-    #[clap(
-        long,
-        value_name = "SLACK_CHANNEL",
-        help = "Name of Slack channel to send messages to (has to be a public channel)",
-        env = "SLACK_CHANNEL"
-    )]
-    pub slack_channel: Option<String>,
+    pub slack_webhook: Option<String>,
     #[clap(
         long,
         value_name = "DISCORD_WEBHOOK",

--- a/subgraph-radio/src/operator/notifier.rs
+++ b/subgraph-radio/src/operator/notifier.rs
@@ -10,8 +10,7 @@ use crate::config::Config;
 #[derive(Clone, Debug, Getters, Serialize, Deserialize, PartialEq)]
 pub struct Notifier {
     radio_name: String,
-    slack_token: Option<String>,
-    slack_channel: Option<String>,
+    slack_webhook: Option<String>,
     discord_webhook: Option<String>,
     telegram_token: Option<String>,
     telegram_chat_id: Option<i64>,
@@ -31,8 +30,7 @@ impl Notifier {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         radio_name: String,
-        slack_token: Option<String>,
-        slack_channel: Option<String>,
+        slack_webhook: Option<String>,
         discord_webhook: Option<String>,
         telegram_token: Option<String>,
         telegram_chat_id: Option<i64>,
@@ -41,8 +39,7 @@ impl Notifier {
     ) -> Notifier {
         Notifier {
             radio_name,
-            slack_token,
-            slack_channel,
+            slack_webhook,
             discord_webhook,
             telegram_token,
             telegram_chat_id,
@@ -53,8 +50,7 @@ impl Notifier {
 
     pub fn from_config(config: &Config) -> Self {
         let radio_name = config.radio_setup().radio_name.clone();
-        let slack_token = config.radio_setup().slack_token.clone();
-        let slack_channel = config.radio_setup().slack_channel.clone();
+        let slack_webhook = config.radio_setup().slack_webhook.clone();
         let discord_webhook = config.radio_setup().discord_webhook.clone();
         let telegram_token = config.radio_setup().telegram_token.clone();
         let telegram_chat_id = config.radio_setup().telegram_chat_id;
@@ -63,8 +59,7 @@ impl Notifier {
 
         Notifier::new(
             radio_name,
-            slack_token,
-            slack_channel,
+            slack_webhook,
             discord_webhook,
             telegram_token,
             telegram_chat_id,
@@ -74,10 +69,8 @@ impl Notifier {
     }
 
     pub async fn notify(&self, content: String) {
-        if let (Some(token), Some(channel)) = (&self.slack_token, &self.slack_channel) {
-            if let Err(e) =
-                SlackBot::send_webhook(token.to_string(), channel, &self.radio_name, &content).await
-            {
+        if let Some(webhook_url) = &self.slack_webhook {
+            if let Err(e) = SlackBot::send_webhook(webhook_url, &self.radio_name, &content).await {
                 warn!(
                     err = tracing::field::debug(e),
                     "Failed to send notification to Slack"

--- a/template.toml
+++ b/template.toml
@@ -15,7 +15,6 @@ topics = ['QmacQnSgia4iDPWHpeY6aWxesRFdb8o5DKZUx96zZqEWrB']
 gossip_topic_coverage = 'Comprehensive'
 auto_upgrade_coverage = 'Comprehensive'
 collect_message_duration = 10
-slack_token = 'xoxb-1231231231231-2312312312312-3abcabcabcabacabcabcabca'
 metrics_host = '0.0.0.0'
 server_host = '0.0.0.0'
 server_port = 7700

--- a/test-utils/src/config.rs
+++ b/test-utils/src/config.rs
@@ -66,8 +66,7 @@ pub fn test_config() -> Config {
                 log_level:
                     "off,hyper=off,graphcast_sdk=trace,subgraph_radio=trace,test_runner=trace"
                         .to_string(),
-                slack_token: None,
-                slack_channel: None,
+                slack_webhook: None,
                 discord_webhook: None,
                 metrics_host: String::new(),
                 metrics_port: None,

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -186,19 +186,11 @@ pub fn start_radio(config: &Config) -> Child {
         .arg(config.waku().waku_port.as_deref().unwrap_or("None"))
         .arg("--log-level")
         .arg(&config.radio_setup().log_level)
-        .arg("--slack-token")
+        .arg("--slack-webhook")
         .arg(
             config
                 .radio_setup()
-                .slack_token
-                .as_deref()
-                .unwrap_or("None"),
-        )
-        .arg("--slack-channel")
-        .arg(
-            config
-                .radio_setup()
-                .slack_channel
+                .slack_webhook
                 .as_deref()
                 .unwrap_or("None"),
         )


### PR DESCRIPTION
`SlackBot` uses webhook url instead of bot token and channel config variables.
Accompanying PR: https://github.com/graphops/graphcast-sdk/pull/312