### PR TITLE
feat: more metrics

### DIFF
--- a/grafana.json
+++ b/grafana.json
@@ -520,7 +520,11 @@
       "type": "table"
     },
     {
-      "datasource": "${DS_PROMETHEUS}",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -577,13 +581,15 @@
         "x": 12,
         "y": 8
       },
-      "id": 123129,
+      "id": 123142,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
+          "calcs": ["last", "min", "max"],
+          "displayMode": "table",
           "placement": "bottom",
-          "showLegend": true
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
         },
         "tooltip": {
           "mode": "single",
@@ -593,32 +599,16 @@
       "targets": [
         {
           "datasource": "${DS_PROMETHEUS}",
-          "exemplar": true,
-          "expr": "function_calls_concurrent",
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "rate(cached_ppoi_messages[ $__rate_interval ])",
           "interval": "",
           "legendFormat": "",
+          "range": true,
           "refId": "A"
-        },
-        {
-          "datasource": "${DS_PROMETHEUS}",
-          "exemplar": true,
-          "expr": "histogram_quantile(0.95, sum(rate(function_calls_duration_bucket[5m])) by (le))",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "B"
-        },
-        {
-          "datasource": "${DS_PROMETHEUS}",
-          "exemplar": true,
-          "expr": "rate(function_calls_count[5m])",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "C"
         }
       ],
-      "title": "Function Call Stats",
+      "title": "Average Message Frequency",
       "type": "timeseries"
     },
     {
@@ -715,6 +705,332 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "graphcast_subgraph_radio_gossip_peers{instance=\"subgraph-radio:2384\", job=\"subgraph-radio\"}"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 123143,
+      "options": {
+        "legend": {
+          "calcs": ["last", "min", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "graphcast_subgraph_radio_average_processing_time",
+          "interval": "",
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Average Processing Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "graphcast_subgraph_radio_gossip_peers{instance=\"subgraph-radio:2384\", job=\"subgraph-radio\"}"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 123144,
+      "options": {
+        "legend": {
+          "calcs": ["last", "min", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "topk(10, sum(rate(frequent_senders_counter[$__interval])) by (indexer_address))",
+          "interval": "",
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Frequent Senders",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 123146,
+      "options": {
+        "legend": {
+          "calcs": ["last", "min", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "graphcast_subgraph_radio_latest_message_timestamp",
+          "interval": "",
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Latest Message Timestamps",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -769,12 +1085,12 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 16
+        "y": 32
       },
-      "id": 123135,
+      "id": 123147,
       "options": {
         "legend": {
-          "calcs": ["last", "min", "max", "sum"],
+          "calcs": ["last", "min", "max"],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true,
@@ -790,15 +1106,117 @@
         {
           "datasource": "${DS_PROMETHEUS}",
           "editorMode": "code",
-          "exemplar": true,
-          "expr": "graphcast_subgraph_radio_local_ppois_to_compare",
+          "exemplar": false,
+          "expr": "graphcast_subgraph_radio_ATTESTED_MAX_STAKE_WEIGHT",
           "interval": "",
-          "legendFormat": "{{deployment}}",
+          "legendFormat": "",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Locally tracked Public POIs",
+      "title": "Max Stake POI",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 40
+      },
+      "id": 123129,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "exemplar": true,
+          "expr": "function_calls_concurrent",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "exemplar": true,
+          "expr": "histogram_quantile(0.95, sum(rate(function_calls_duration_bucket[5m])) by (le))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "exemplar": true,
+          "expr": "rate(function_calls_count[5m])",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "C"
+        }
+      ],
+      "title": "Function Call Stats",
       "type": "timeseries"
     }
   ],
@@ -834,6 +1252,6 @@
   "timezone": "browser",
   "title": "Graphcast Subgraph Radio",
   "uid": "graphcast-subgraph-radio",
-  "version": 17,
+  "version": 20,
   "weekStart": ""
 }

--- a/subgraph-radio/src/config.rs
+++ b/subgraph-radio/src/config.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use tracing::info;
 
+use crate::metrics::NUM_TOPICS;
 use crate::operator::notifier::NotificationMode;
 use crate::{active_allocation_hashes, syncing_deployment_hashes};
 
@@ -227,6 +228,8 @@ impl Config {
                 additional_topics
             }
         };
+
+        NUM_TOPICS.set(topics.len() as i64);
         topics.into_iter().collect::<Vec<String>>()
     }
 

--- a/subgraph-radio/src/metrics/mod.rs
+++ b/subgraph-radio/src/metrics/mod.rs
@@ -5,7 +5,7 @@ use axum::Router;
 use axum_server::Handle;
 use once_cell::sync::Lazy;
 use prometheus::{core::Collector, Registry};
-use prometheus::{IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Opts};
+use prometheus::{Gauge, GaugeVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Opts};
 
 use std::{net::SocketAddr, str::FromStr};
 use tracing::{debug, info};
@@ -52,7 +52,7 @@ pub static ACTIVE_INDEXERS: Lazy<IntGaugeVec> = Lazy::new(|| {
         .subsystem("subgraph_radio"),
         &["deployment"],
     )
-    .expect("Failed to create ACTIVE_INDEXERS gauges");
+    .expect("Failed to create ACTIVE_INDEXERS gauge");
     prometheus::register(Box::new(m.clone())).expect("Failed to register ACTIVE_INDEXERS counter");
     m
 });
@@ -114,6 +114,99 @@ pub static RECEIVED_MESSAGES: Lazy<IntCounter> = Lazy::new(|| {
 });
 
 #[allow(dead_code)]
+pub static AVERAGE_PROCESSING_TIME: Lazy<Gauge> = Lazy::new(|| {
+    let m = Gauge::with_opts(
+        Opts::new(
+            "average_processing_time",
+            "Average time taken to process each POI message",
+        )
+        .namespace("graphcast")
+        .subsystem("subgraph_radio"),
+    )
+    .expect("Failed to create average_processing_time gauge");
+    prometheus::register(Box::new(m.clone()))
+        .expect("Failed to register average_processing_time gauge");
+    m
+});
+
+#[allow(dead_code)]
+pub static FREQUENT_SENDERS_COUNTER: Lazy<IntCounterVec> = Lazy::new(|| {
+    let m = IntCounterVec::new(
+        Opts::new(
+            "frequent_senders",
+            "Count of messages received from each indexer",
+        )
+        .namespace("graphcast")
+        .subsystem("subgraph_radio"),
+        &["indexer_address"],
+    )
+    .expect("Failed to create frequent_senders counter");
+    prometheus::register(Box::new(m.clone())).expect("Failed to register frequent_senders counter");
+    m
+});
+
+#[allow(dead_code)]
+pub static LATEST_MESSAGE_TIMESTAMP: Lazy<GaugeVec> = Lazy::new(|| {
+    let m = GaugeVec::new(
+        Opts::new(
+            "latest_message_timestamp",
+            "Timestamp of the last received public POI message",
+        )
+        .namespace("graphcast")
+        .subsystem("subgraph_radio"),
+        &["deployment_hash"],
+    )
+    .expect("Failed to create latest_message_timestamp gauge");
+    prometheus::register(Box::new(m.clone()))
+        .expect("Failed to register latest_message_timestamp gauge");
+    m
+});
+
+#[allow(dead_code)]
+pub static ATTESTED_MAX_STAKE_WEIGHT: Lazy<GaugeVec> = Lazy::new(|| {
+    let m = GaugeVec::new(
+        Opts::new("ATTESTED_MAX_STAKE_WEIGHT", "Highest stake-backed POI")
+            .namespace("graphcast")
+            .subsystem("subgraph_radio"),
+        &["deployment_hash"],
+    )
+    .expect("Failed to create ATTESTED_MAX_STAKE_WEIGHT gauge");
+    prometheus::register(Box::new(m.clone())).expect("Failed to register max_poi_stake gauge");
+    m
+});
+
+#[allow(dead_code)]
+pub static NUM_TOPICS: Lazy<IntGauge> = Lazy::new(|| {
+    let m = IntGauge::with_opts(
+        Opts::new(
+            "num_topics",
+            "Number of topics (subgraphs) being actively cross-checked",
+        )
+        .namespace("graphcast")
+        .subsystem("subgraph_radio"),
+    )
+    .expect("Failed to create num_topics gauge");
+    prometheus::register(Box::new(m.clone())).expect("Failed to register num_topics gauge");
+    m
+});
+
+#[allow(dead_code)]
+pub static COMPARISON_RESULTS: Lazy<IntGaugeVec> = Lazy::new(|| {
+    let m = IntGaugeVec::new(
+        Opts::new(
+            "COMPARISON_RESULTS",
+            "Rate of comparison results for each deployment",
+        )
+        .namespace("graphcast")
+        .subsystem("subgraph_radio"),
+        &["deployment"],
+    )
+    .expect("Failed to create COMPARISON_RESULTS gauge");
+    prometheus::register(Box::new(m.clone())).expect("Failed to register COMPARISON_RESULTS gauge");
+    m
+});
+
+#[allow(dead_code)]
 pub static REGISTRY: Lazy<prometheus::Registry> = Lazy::new(prometheus::Registry::new);
 
 #[allow(dead_code)]
@@ -136,6 +229,12 @@ pub fn start_metrics() {
             Box::new(CONNECTED_PEERS.clone()),
             Box::new(GOSSIP_PEERS.clone()),
             Box::new(RECEIVED_MESSAGES.clone()),
+            Box::new(AVERAGE_PROCESSING_TIME.clone()),
+            Box::new(FREQUENT_SENDERS_COUNTER.clone()),
+            Box::new(LATEST_MESSAGE_TIMESTAMP.clone()),
+            Box::new(ATTESTED_MAX_STAKE_WEIGHT.clone()),
+            Box::new(NUM_TOPICS.clone()),
+            Box::new(COMPARISON_RESULTS.clone()),
         ],
     );
 }

--- a/subgraph-radio/src/operator/attestation.rs
+++ b/subgraph-radio/src/operator/attestation.rs
@@ -2,6 +2,10 @@ use crate::database::{
     clear_all_notifications, create_notification, get_comparison_results_by_deployment,
     get_notifications, get_remote_ppoi_messages_by_identifier, save_comparison_result,
 };
+use crate::metrics::{
+    ATTESTED_MAX_STAKE_WEIGHT, AVERAGE_PROCESSING_TIME, COMPARISON_RESULTS,
+    FREQUENT_SENDERS_COUNTER, LATEST_MESSAGE_TIMESTAMP,
+};
 use crate::operator::notifier::NotificationMode;
 use crate::DatabaseError;
 use async_graphql::{Enum, Error as AsyncGraphqlError, ErrorExtensions, SimpleObject};
@@ -13,6 +17,7 @@ use sqlx::SqlitePool;
 use std::error::Error;
 use std::fmt;
 use std::str::FromStr;
+use std::time::Instant;
 use std::{
     collections::{HashMap, HashSet},
     fmt::Display,
@@ -109,6 +114,8 @@ pub async fn process_ppoi_message(
     messages: Vec<GraphcastMessage<PublicPoiMessage>>,
     callbook: &CallBook,
 ) -> Result<RemoteAttestationsMap, AttestationError> {
+    let start_time = Instant::now();
+
     let mut remote_attestations: RemoteAttestationsMap = HashMap::new();
     // Check if there are existing attestations for the block
     let first_message = messages.first();
@@ -127,6 +134,14 @@ pub async fn process_ppoi_message(
                 .await
                 .map_err(|e| AttestationError::BuildError(MessageError::FieldDerivations(e)))?
                 as u64;
+
+        FREQUENT_SENDERS_COUNTER
+            .with_label_values(&[&radio_msg.graph_account])
+            .inc();
+
+        LATEST_MESSAGE_TIMESTAMP
+            .with_label_values(&[&msg.identifier])
+            .set(radio_msg.nonce as f64);
 
         let blocks = remote_attestations
             .entry(msg.identifier.to_string())
@@ -173,6 +188,10 @@ pub async fn process_ppoi_message(
     let active_indexers = ACTIVE_INDEXERS.with_label_values(&[&first_msg.identifier.to_string()]);
     let senders = combine_senders(blocks.entry(first_msg.payload.block_number).or_default());
     active_indexers.set(senders.len().try_into().unwrap());
+
+    let duration = start_time.elapsed();
+    let average_time = duration.as_secs_f64() / messages.len() as f64;
+    AVERAGE_PROCESSING_TIME.set(average_time);
 
     Ok(remote_attestations)
 }
@@ -306,6 +325,10 @@ pub async fn handle_comparison_result(
         .await?
         .into_iter()
         .next();
+
+    COMPARISON_RESULTS
+        .with_label_values(&[&deployment_hash])
+        .inc();
 
     // Determine if the state has changed and if the database operation is successful
     let is_state_changed = existing_result.as_ref().map_or(true, |current_result| {
@@ -468,9 +491,17 @@ pub fn compare_attestations(
             .unwrap_or(std::cmp::Ordering::Equal)
     });
 
+    let most_attested_poi = sorted_remote_attestations.last().cloned();
+
+    if let Some(attestation) = &most_attested_poi {
+        ATTESTED_MAX_STAKE_WEIGHT
+            .with_label_values(&[ipfs_hash])
+            .set(attestation.stake_weight as f64);
+    }
+
     // Determine the comparison result based on the top attested remote PPOI
     let result_type = if let Some(local_att) = &local_attestation {
-        if let Some(most_attested) = sorted_remote_attestations.last() {
+        if let Some(most_attested) = &most_attested_poi {
             if most_attested.ppoi == local_att.ppoi {
                 ComparisonResultType::Match
             } else {

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -88,7 +88,7 @@ pub struct ProcessManager {
 
 impl Drop for ProcessManager {
     fn drop(&mut self) {
-        let _ = self.senders.get(0).unwrap().lock().unwrap().kill();
+        let _ = self.senders.first().unwrap().lock().unwrap().kill();
         let _ = self.radio.lock().unwrap().kill();
     }
 }


### PR DESCRIPTION
Issue: https://github.com/graphops/subgraph-radio/issues/83

**Metrics updates:**
- [x] Total Message Count - this was already covered by `CACHED_PPOI_MESSAGES`, I think
- [x] Average message frequency - I think we can use `CACHED_PPOI_MESSAGES` for this, with this promql query on Grafana `rate(cached_ppoi_messages[ $__rate_interval ])`
- [x] Average Processing Time - new metric `AVERAGE_PROCESSING_TIME` that tracks the execution time of `process_ppoi_message`
- [x] Frequent senders - new metric `FREQUENT_SENDERS_COUNTER`, which is updated in `process_ppoi_message`, presented in Grafana using `topk(10, sum(rate(frequent_senders_counter[$__interval])) by (indexer_address))`
- [x] Divergence Rate - using the current metrics `CACHED_PPOI_MESSAGES` and `DIVERGING_SUBGRAPHS` and this query `(DIVERGING_SUBGRAPHS / sum(CACHED_PPOI_MESSAGES)) * 100` we can display the divergence rate
- [x] Latest Message Timestamp - to make things easier we have a new metric `LATEST_MESSAGE_TIMESTAMP` which also gets updated in `process_ppoi_message`
- [x] POI stakes for Deployment - new metric `MAX_STAKE_POI` that gets updated in `compare_attestations` when we get the most attested poi. Still mulling over the name though 🤔 
- [x] Network connectivity - we already have the gossip peers, it was mislabelled on the dashboard, and frequent senders reflects the actual Indexers now 

**Other changes:**
- [x] updated `grafana.json`