### PR TITLE
fix: Add metadata write perm for docker builds in CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      metadata: write
 
     steps:
       - name: Checkout


### PR DESCRIPTION
### Description

Add metadata write perm for docker builds in CI
