### PR TITLE
fix: setting permissions to write all for docker publishing workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,10 +16,7 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: read
-      packages: write
-      metadata: write
+    permissions: write-all
 
     steps:
       - name: Checkout


### PR DESCRIPTION
### Description

setting permissions to write all for docker publishing workflow