### PR TITLE
fix: Fix duplicate entries in grafana poi comparison results table

### DIFF
--- a/grafana.json
+++ b/grafana.json
@@ -659,6 +659,29 @@
             "match": "any",
             "type": "exclude"
           }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "blockNumber": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "deployment": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "senderRatio": {
+                "aggregations": ["last"],
+                "operation": "aggregate"
+              },
+              "stakeRatio": {
+                "aggregations": ["last"],
+                "operation": "aggregate"
+              }
+            }
+          }
         }
       ],
       "type": "table"


### PR DESCRIPTION
### Description

Fix duplicate entries in grafana poi comparison results table

### Issue link (if applicable)

https://github.com/graphops/subgraph-radio/issues/176