### PR TITLE
chore: release 1.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.8] - 2025-01-10
+
+### Miscellaneous Tasks
+
+- Fix Grafana Dashboard duplication bug
+
 ## [1.0.7] - 2024-11-15
 
 ### Miscellaneous Tasks

--- a/subgraph-radio/Cargo.toml
+++ b/subgraph-radio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "subgraph-radio"
-version = "1.0.7"
+version = "1.0.8"
 edition = "2021"
 authors = ["GraphOps (axiomatic-aardvark, hopeyen)"]
 description = "Subgraph Radio monitors subgraph PublicPoI and UpgradeIntent messages in real time using Graphcast SDK"


### PR DESCRIPTION
### Description

release 1.0.8
de-dupe grafana dashboard